### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## ADAPT Training App
  iOS App and node.js Server Database App
 
-- For iOS, open Adapt.xcodeproj
+- For iOS, open Adapt.xcworkspace
 - For server, go to Server/


### PR DESCRIPTION
Now that we are using cocoapods, change README to inform that the xcworkspace file should be used to open the iOS App instead of the .xcodeproj file.